### PR TITLE
chore: add blocklist export to pkgjs

### DIFF
--- a/.github/workflows/export-blocklist-pkgjs.yml
+++ b/.github/workflows/export-blocklist-pkgjs.yml
@@ -1,0 +1,14 @@
+name: Import Blocklist
+on:
+    workflow_dispatch:
+
+jobs:
+  import_blocklist:
+    if: github.repository == 'nodejs/.github' # only try to run when in the originating repo, since forks will be missing the token
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pkgjs/action-import-blocklist@HEAD
+        with:
+          sourceOrganization: nodejs # we take the nodejs blocklist
+          targetOrganization: pkgjs # and push it somewhere else - in this case, the pkgjs org
+          token: ${{ secrets.BLOCKLIST_TOKEN }}

--- a/.github/workflows/export-blocklist-pkgjs.yml
+++ b/.github/workflows/export-blocklist-pkgjs.yml
@@ -1,4 +1,4 @@
-name: Import Blocklist
+name: Export blocklist to pkgjs
 on:
     workflow_dispatch:
 

--- a/.github/workflows/export-blocklist-pkgjs.yml
+++ b/.github/workflows/export-blocklist-pkgjs.yml
@@ -3,7 +3,7 @@ on:
     workflow_dispatch:
 
 jobs:
-  import_blocklist:
+  export_blocklist:
     if: github.repository == 'nodejs/.github' # only try to run when in the originating repo, since forks will be missing the token
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds a GitHub action using [pkgjs/action-import-blocklist](https://github.com/pkgjs/action-import-blocklist) to export the Node.js GitHub Org's blocklist to the pkgjs GitHub organization.

Note that this must have a GitHub token that **requires** the `admin:org` scope, meaning it must come from an account that has access to that scope in _both_ organizations. You can see the requirement for this in GitHub's documentation [here](https://docs.github.com/en/rest/reference/orgs#blocking-users).