### PR TITLE
chore(readme): add a global profile on the org readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Run JavaScript <a href="https://nodejs.org/en/download">Everywhere</a>.®</h1><br>
+<h1 align="center">Run JavaScript <a href="https://nodejs.org/en/download">Everywhere</a>.</h1><br>
 
 <p align="center">
   <a href="https://nodejs.org/">

--- a/profile/README.md
+++ b/profile/README.md
@@ -22,14 +22,14 @@
 
 ----
 
-#### Contributing to Node.js
+#### 👋 Contributing to Node.js.
 
 <sub> Node.js is an open source project, and it's always looking for new contributions. From documentation, translation, contributing to our infrastructure or reporting a bug; Any contribution is valued and welcome. Are you interested in contributing to Node.js? Give a read to our [Governance Model](https://github.com/nodejs/node/blob/main/GOVERNANCE.md) and the numerous ways you can [Get Involved](https://nodejs.org/en/get-involved) with Node.js!</sub>
 
-#### Please abide by our Code of Conduct
+#### 🦺 Help us making this Community safe.
 
 <sub>Ths Node.js GitHub org(anisation) follows the [OpenJS Foundation](https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md) and [Node.js's Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md). Please abide with this Code of Conduct when interacting with all repositories under the Node.js umbrella and when interacting with people.</sub>
 
-#### Security-Reporting
+#### 👾 Reporting Security Incidents.
 
-<sub>Please be mindfull that Security-related issues should be reported through our [Security Policy](https://github.com/nodejs/node/security/policy) as Security-related issues and vulnerabilities can be exploited and we request confidentiality whenever possible.</sub>
+<sub>Please be mindful that Security-related issues should be reported through our [Security Policy](https://github.com/nodejs/node/security/policy) as Security-related issues and vulnerabilities can be exploited and we request confidentiality whenever possible.</sub>

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://nodejs.org/">
-    <img src="https://raw.githubusercontent.com/nodejs/nodejs.org/main/public/static/images/logo-hexagon.svg" alt="Bootstrap logo" height="140">
+    <img src="https://raw.githubusercontent.com/nodejs/nodejs.org/main/public/static/images/logo-hexagon.svg" alt="Node.js logo" height="140">
   </a>
 </p>
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,21 @@
+<h1 align="center">Run JavaScript <a href="https://nodejs.org/en/download">Everywhere</a>.®</h1><br>
+
+<p align="center">
+  <a href="https://nodejs.org/">
+    <img src="https://raw.githubusercontent.com/nodejs/nodejs.org/main/public/static/images/logo-hexagon.svg" alt="Bootstrap logo" height="140">
+  </a>
+</p>
+
+<p align="center">
+  Node.js® is a free, open-sourced, cross-platform JavaScript run-time environment that lets developers write command line tools and server-side scripts outside of a browser.
+</p>
+
+<p align="center">
+  <a href="https://nodejs.org/en/download">Get Node.js® ✨</a>
+  ·
+  <a href="https://github.com/nodejs/node/issues/new/choose">Report a bug on Node.js 🐞</a>
+  ·
+  <a href="https://nodejs.org/en/get-involved">Contribute to Node.js 🫶</a>
+  ·
+  <a href="https://openjsf.org/certification/">Get Certified 🎓</a>
+</p>

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  Node.js® is a free, open-sourced, cross-platform JavaScript run-time environment that lets developers write command line tools and server-side scripts outside of a browser.
+  Node.js® is a free, open-sourced, cross-platform JavaScript run-time environment—<br> that lets developers write command line tools and server-side scripts outside of a browser.
 </p>
 
 <p align="center">
@@ -19,3 +19,17 @@
   ·
   <a href="https://openjsf.org/certification/">Get Certified 🎓</a>
 </p>
+
+----
+
+#### Contributing to Node.js
+
+<sub> Node.js is an open source project, and it's always looking for new contributions. From documentation, translation, contributing to our infrastructure or reporting a bug; Any contribution is valued and welcome. Are you interested in contributing to Node.js? Give a read to our [Governance Model](https://github.com/nodejs/node/blob/main/GOVERNANCE.md) and the numerous ways you can [Get Involved](https://nodejs.org/en/get-involved) with Node.js!</sub>
+
+#### Please abide by our Code of Conduct
+
+<sub>Ths Node.js GitHub org(anisation) follows the [OpenJS Foundation](https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md) and [Node.js's Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md). Please abide with this Code of Conduct when interacting with all repositories under the Node.js umbrella and when interacting with people.</sub>
+
+#### Security-Reporting
+
+<sub>Please be mindfull that Security-related issues should be reported through our [Security Policy](https://github.com/nodejs/node/security/policy) as Security-related issues and vulnerabilities can be exploited and we request confidentiality whenever possible.</sub>


### PR DESCRIPTION
This PR adds a public profile on the GitHub organisation, adding handy links and a nice overview of the Node.js GitHub org.

cc @nodejs/tsc 