### PR TITLE
chore: two grammar changes in profile readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -26,7 +26,7 @@
 
 <sub>Node.js is an open-source project, and it's always looking for new contributions. From documentation, translation, contributing to our infrastructure or reporting a bug; Any contribution is valued and welcome. Are you interested in contributing to Node.js? Give a read to our [Governance Model](https://github.com/nodejs/node/blob/main/GOVERNANCE.md) and the numerous ways you can [Get Involved](https://nodejs.org/en/get-involved) with Node.js!</sub>
 
-#### 🦺 Making this Community safe.
+#### 🦺 Help us make this Community safe.
 
 <sub>The Node.js GitHub org(anization) follows the [OpenJS Foundation](https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md) and [Node.js's Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md). Please abide by this Code of Conduct when interacting with all repositories under the Node.js umbrella and when interacting with people.</sub>
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  Node.js® is a free, open-source, cross-platform JavaScript run-time environment—<br> that lets developers write command line tools and server-side scripts outside of a browser.
+  Node.js® is a free, open-source, cross-platform JavaScript run-time environment <br>that lets developers write command line tools and server-side scripts outside of a browser.
 </p>
 
 <p align="center">
@@ -26,7 +26,7 @@
 
 <sub>Node.js is an open-source project, and it's always looking for new contributions. From documentation, translation, contributing to our infrastructure or reporting a bug; Any contribution is valued and welcome. Are you interested in contributing to Node.js? Give a read to our [Governance Model](https://github.com/nodejs/node/blob/main/GOVERNANCE.md) and the numerous ways you can [Get Involved](https://nodejs.org/en/get-involved) with Node.js!</sub>
 
-#### 🦺 Help us making this Community safe.
+#### 🦺 Making this Community safe.
 
 <sub>The Node.js GitHub org(anization) follows the [OpenJS Foundation](https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md) and [Node.js's Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md). Please abide by this Code of Conduct when interacting with all repositories under the Node.js umbrella and when interacting with people.</sub>
 


### PR DESCRIPTION
Hello! I wanted to propose two small grammar changes that I hope will refine the `nodejs` GitHub organization's profile readme.

### 1. Remove Unnecessary Em Dash

The current readme has an em dash in the middle of its opening sentence:

> Node.js® is a free, open-source, cross-platform JavaScript run-time environment—that lets developers write command line tools and server-side scripts outside of a browser.

Em dash usage is **subjective**, but I don't think it belongs here. Em dashes are _generally_ best for [moving sentences in a new direction](https://www.merriam-webster.com/grammar/em-dash-en-dash-how-to-use), like a "more powerful" parenthetical.

In my view, the current sentence in the profile readme does not need a separator of any kind. It's not expressing two ideas. It's one singular, coherent explanation of Node.js, and I think it works better as a single clause:

> Node.js® is a free, open-source, cross-platform JavaScript run-time environment that lets developers write command line tools and server-side scripts outside of a browser.

### 2. Fix Typo in Code of Conduct Section

The readme's section about the Code of Conduct currently has a typo (emphasis mine):

> Help us **making** this Community safe.

There are several ways this could be fixed. I've proposed the following in this PR:

> Making this Community safe.

This is a small change, and in my view maintains a good consistency across the main verb of each header:

> 👋 Contributing ...
> 🦺 Making ...
> 👾 Reporting ...

But there are other ways this could be fixed. Alternative ideas include:

> Help us in making this Community safe.
> Help us make this Community safe.
