### PR TITLE
link to `HEAD` rather than `main`

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -24,11 +24,11 @@
 
 #### 👋 Contributing to Node.js.
 
-<sub>Node.js is an open-source project, and it's always looking for new contributions. From documentation, translation, contributing to our infrastructure or reporting a bug; Any contribution is valued and welcome. Are you interested in contributing to Node.js? Give a read to our [Governance Model](https://github.com/nodejs/node/blob/main/GOVERNANCE.md) and the numerous ways you can [Get Involved](https://nodejs.org/en/get-involved) with Node.js!</sub>
+<sub>Node.js is an open-source project, and it's always looking for new contributions. From documentation, translation, contributing to our infrastructure or reporting a bug; Any contribution is valued and welcome. Are you interested in contributing to Node.js? Give a read to our [Governance Model](https://github.com/nodejs/node/blob/HEAD/GOVERNANCE.md) and the numerous ways you can [Get Involved](https://nodejs.org/en/get-involved) with Node.js!</sub>
 
 #### 🦺 Help us making this Community safe.
 
-<sub>The Node.js GitHub org(anization) follows the [OpenJS Foundation](https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md) and [Node.js's Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md). Please abide by this Code of Conduct when interacting with all repositories under the Node.js umbrella and when interacting with people.</sub>
+<sub>The Node.js GitHub org(anization) follows the [OpenJS Foundation](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CODE_OF_CONDUCT.md) and [Node.js's Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md). Please abide by this Code of Conduct when interacting with all repositories under the Node.js umbrella and when interacting with people.</sub>
 
 #### 👾 Reporting Security Incidents.
 


### PR DESCRIPTION
This PR updates the organization's README to prefer linking to any given repositories `HEAD` branch (The default branch) rather than the `main` branch. If for some reason the default branch switches, `HEAD` will always point to it.